### PR TITLE
Implement restore safety checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ rmz example
 
 # 詳細モードで実行
 rmz example --verbose
+# 既存ファイルを強制上書きで復元
+rmz restore --id <uuid> --force
+# 既存ファイルがある場合は自動リネーム
+rmz restore --id <uuid> --rename
 ```
 
 ## 開発

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,6 +75,14 @@ pub enum Commands {
         /// Restore to specific path instead of original location
         #[arg(long)]
         to: Option<PathBuf>,
+
+        /// Overwrite existing files without confirmation
+        #[arg(long)]
+        force: bool,
+
+        /// Automatically rename restored file if target exists
+        #[arg(long, conflicts_with = "force")]
+        rename: bool,
     },
 
     /// List deleted files in trash zone

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -158,7 +158,7 @@ mod tests {
 
         match &result {
             Ok(_) => {}
-            Err(e) => panic!("Delete failed: {}", e),
+            Err(e) => panic!("Delete failed: {e}"),
         }
         assert!(!file_path.exists()); // Original file should be gone
     }
@@ -201,8 +201,10 @@ mod tests {
     #[test]
     fn test_delete_protected_file() {
         let temp_dir = TempDir::new().unwrap();
-        let mut config = Config::default();
-        config.trash_path = temp_dir.path().join("trash");
+        let mut config = Config {
+            trash_path: temp_dir.path().join("trash"),
+            ..Default::default()
+        };
 
         // Add a protected path
         let protected_dir = temp_dir.path().join("protected");

--- a/src/commands/example.rs
+++ b/src/commands/example.rs
@@ -4,9 +4,9 @@ pub fn execute(verbose: bool) -> anyhow::Result<()> {
     if verbose {
         println!("{}", "Running in verbose mode".green());
     }
-    
+
     println!("{}: {}", "rmz".blue().bold(), "The next gen rm command");
     println!("Example command executed successfully!");
-    
+
     Ok(())
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -159,7 +159,7 @@ fn output_json(items: &[TrashItem], verbose: bool) -> Result<()> {
         .collect();
 
     let json = serde_json::to_string_pretty(&json_items)?;
-    println!("{}", json);
+    println!("{json}");
     Ok(())
 }
 
@@ -244,7 +244,7 @@ fn output_single_item(item: &TrashItem, verbose: bool, prefix: &str) {
     let deleted_time = item.meta.deleted_at.format("%Y-%m-%d %H:%M:%S");
 
     if verbose {
-        println!("{}📄 {} ({})", prefix, filename, size);
+        println!("{prefix}📄 {filename} ({size})");
         println!("{}   ID: {}", prefix, item.meta.id);
         println!(
             "{}   Original: {}",
@@ -364,8 +364,8 @@ mod tests {
         fs::write(test_file1.path(), "content1").unwrap();
         fs::write(test_file2.path(), "content2").unwrap();
 
-        let mut meta1 = FileMeta::from_path(&test_file1.path()).unwrap();
-        let mut meta2 = FileMeta::from_path(&test_file2.path()).unwrap();
+        let mut meta1 = FileMeta::from_path(test_file1.path()).unwrap();
+        let mut meta2 = FileMeta::from_path(test_file2.path()).unwrap();
 
         // Add tags for testing
         meta1.add_tag("test".to_string());
@@ -394,7 +394,7 @@ mod tests {
         // Create test file
         let test_file = NamedTempFile::new().unwrap();
         fs::write(test_file.path(), "test content").unwrap();
-        let meta = FileMeta::from_path(&test_file.path()).unwrap();
+        let meta = FileMeta::from_path(test_file.path()).unwrap();
 
         trash_store.save(&meta, test_file.path()).unwrap();
         let items = trash_store.list().unwrap();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -28,7 +28,12 @@ pub fn execute_command(cli: Cli) -> anyhow::Result<()> {
             interactive,
             all,
             to,
-        } => restore::execute(file, id, interactive, all, to, cli.verbose),
+            force,
+            rename,
+        } => {
+            let opts = restore::RestoreOpts { to, force, rename };
+            restore::execute(file, id, interactive, all, opts, cli.verbose)
+        }
         Commands::List {
             json,
             filter,

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -4,12 +4,18 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 /// Execute restore command
+pub struct RestoreOpts {
+    pub to: Option<PathBuf>,
+    pub force: bool,
+    pub rename: bool,
+}
+
 pub fn execute(
     file: Option<String>,
     id: Option<String>,
     interactive: bool,
     all: bool,
-    to: Option<PathBuf>,
+    opts: RestoreOpts,
     verbose: bool,
 ) -> Result<()> {
     let config = ConfigManager::load()?;
@@ -17,16 +23,16 @@ pub fn execute(
 
     if let Some(id_str) = id {
         // Restore by specific ID
-        restore_by_id(&trash_store, &id_str, to, verbose)
+        restore_by_id(&trash_store, &id_str, &opts, verbose)
     } else if all {
         // Restore all files (with optional filter)
-        restore_all(&trash_store, file, to, verbose)
+        restore_all(&trash_store, file, &opts, verbose)
     } else if interactive {
         // Interactive restore using fuzzy finder
-        restore_interactive(&trash_store, file, to, verbose)
+        restore_interactive(&trash_store, file, opts.to.clone(), verbose)
     } else if let Some(pattern) = file {
         // Restore by file pattern
-        restore_by_pattern(&trash_store, &pattern, to, verbose)
+        restore_by_pattern(&trash_store, &pattern, &opts, verbose)
     } else {
         anyhow::bail!("Must specify one of: --id, --all, --interactive, or file pattern");
     }
@@ -35,39 +41,14 @@ pub fn execute(
 fn restore_by_id(
     trash_store: &TrashStore,
     id_str: &str,
-    to: Option<PathBuf>,
+    opts: &RestoreOpts,
     verbose: bool,
 ) -> Result<()> {
     let id =
         Uuid::parse_str(id_str).map_err(|_| anyhow::anyhow!("Invalid UUID format: {}", id_str))?;
 
     if let Some(item) = trash_store.find_by_id(&id)? {
-        let restore_path = if let Some(to_path) = to {
-            // Restore to specific location
-            let final_path = if to_path.is_dir() {
-                // If target is directory, use original filename
-                if let Some(filename) = item.meta.filename() {
-                    to_path.join(filename)
-                } else {
-                    anyhow::bail!("Cannot determine filename for restoration");
-                }
-            } else {
-                to_path
-            };
-
-            // Ensure parent directory exists
-            if let Some(parent) = final_path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-
-            // Move file to new location
-            std::fs::rename(&item.trash_path, &final_path)?;
-            final_path
-        } else {
-            // Restore to original location
-            trash_store.restore(&id)?
-        };
-
+        let restore_path = restore_single_item(trash_store, &item, opts, verbose)?;
         if verbose {
             println!("✅ Restored: {} -> {}", id, restore_path.display());
         } else {
@@ -83,7 +64,7 @@ fn restore_by_id(
 fn restore_all(
     trash_store: &TrashStore,
     filter: Option<String>,
-    to: Option<PathBuf>,
+    opts: &RestoreOpts,
     verbose: bool,
 ) -> Result<()> {
     let items = trash_store.list()?;
@@ -117,7 +98,7 @@ fn restore_all(
 
     let mut restored_count = 0;
     for item in filtered_items {
-        match restore_single_item(trash_store, &item, to.clone(), verbose) {
+        match restore_single_item(trash_store, &item, opts, verbose) {
             Ok(path) => {
                 restored_count += 1;
                 if verbose {
@@ -134,14 +115,14 @@ fn restore_all(
         }
     }
 
-    println!("Restored {} file(s)", restored_count);
+    println!("Restored {restored_count} file(s)");
     Ok(())
 }
 
 fn restore_by_pattern(
     trash_store: &TrashStore,
     pattern: &str,
-    to: Option<PathBuf>,
+    opts: &RestoreOpts,
     verbose: bool,
 ) -> Result<()> {
     let items = trash_store.list()?;
@@ -151,18 +132,18 @@ fn restore_by_pattern(
         .collect();
 
     if matching_items.is_empty() {
-        println!("No files matching '{}' found in trash", pattern);
+        println!("No files matching '{pattern}' found in trash");
         return Ok(());
     }
 
     if matching_items.len() == 1 {
         // Single match, restore directly
         let item = &matching_items[0];
-        let path = restore_single_item(trash_store, item, to, verbose)?;
+        let path = restore_single_item(trash_store, item, opts, verbose)?;
         println!("Restored: {}", path.display());
     } else {
         // Multiple matches, show list and ask for selection
-        println!("Multiple files match '{}': ", pattern);
+        println!("Multiple files match '{pattern}': ");
         for (i, item) in matching_items.iter().enumerate() {
             println!(
                 "  {}: {} ({})",
@@ -175,7 +156,7 @@ fn restore_by_pattern(
         // For now, restore all matching files
         // TODO: Add interactive selection
         for item in matching_items {
-            match restore_single_item(trash_store, &item, to.clone(), verbose) {
+            match restore_single_item(trash_store, &item, opts, verbose) {
                 Ok(path) => {
                     if verbose {
                         println!("✅ Restored: {}", path.display());
@@ -208,35 +189,59 @@ fn restore_interactive(
 fn restore_single_item(
     trash_store: &TrashStore,
     item: &crate::domain::TrashItem,
-    to: Option<PathBuf>,
+    opts: &RestoreOpts,
     _verbose: bool,
 ) -> Result<PathBuf> {
-    if let Some(to_path) = to {
-        // Restore to specific location
-        let final_path = if to_path.is_dir() {
+    use crate::utils::file_safety::{
+        check_existing_file, generate_safe_restore_path, RestoreAction,
+    };
+
+    let mut final_path = if let Some(to_path) = opts.to.as_ref() {
+        if to_path.is_dir() {
             if let Some(filename) = item.meta.filename() {
                 to_path.join(filename)
             } else {
                 anyhow::bail!("Cannot determine filename for restoration");
             }
         } else {
-            to_path
-        };
+            to_path.clone()
+        }
+    } else {
+        item.meta.original_path.clone()
+    };
 
-        // Ensure parent directory exists
+    if final_path.exists() {
+        if opts.force {
+            // overwrite
+        } else if opts.rename {
+            final_path = generate_safe_restore_path(&final_path);
+        } else {
+            match check_existing_file(&final_path)? {
+                RestoreAction::Overwrite => {}
+                RestoreAction::Skip => {
+                    anyhow::bail!("Restoration skipped");
+                }
+                RestoreAction::Rename => {
+                    final_path = generate_safe_restore_path(&final_path);
+                }
+                RestoreAction::Cancel => {
+                    anyhow::bail!("Restoration cancelled");
+                }
+                RestoreAction::Proceed => {}
+            }
+        }
+    }
+
+    if opts.to.is_none() && final_path == item.meta.original_path {
+        // Use TrashStore to handle metadata cleanup
+        trash_store.restore(&item.meta.id)?;
+        Ok(final_path)
+    } else {
         if let Some(parent) = final_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-
-        // Move file to new location
         std::fs::rename(&item.trash_path, &final_path)?;
-
-        // Remove metadata (manual cleanup since we're not using trash_store.restore())
-        // Note: This is a bit awkward - we should refactor TrashStore to handle this better
         Ok(final_path)
-    } else {
-        // Restore to original location
-        trash_store.restore(&item.meta.id)
     }
 }
 
@@ -283,7 +288,12 @@ mod tests {
         assert!(!original_path.exists());
 
         // Restore by ID
-        let result = restore_by_id(&trash_store, &id.to_string(), None, false);
+        let opts = RestoreOpts {
+            to: None,
+            force: false,
+            rename: false,
+        };
+        let result = restore_by_id(&trash_store, &id.to_string(), &opts, false);
         assert!(result.is_ok());
         assert!(original_path.exists());
         assert_eq!(fs::read_to_string(&original_path).unwrap(), "test content");
@@ -294,7 +304,12 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let trash_store = TrashStore::new(temp_dir.path().join("trash"));
 
-        let result = restore_by_id(&trash_store, "invalid-uuid", None, false);
+        let opts = RestoreOpts {
+            to: None,
+            force: false,
+            rename: false,
+        };
+        let result = restore_by_id(&trash_store, "invalid-uuid", &opts, false);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -308,7 +323,12 @@ mod tests {
         let trash_store = TrashStore::new(temp_dir.path().join("trash"));
 
         let nonexistent_id = uuid::Uuid::new_v4();
-        let result = restore_by_id(&trash_store, &nonexistent_id.to_string(), None, false);
+        let opts = RestoreOpts {
+            to: None,
+            force: false,
+            rename: false,
+        };
+        let result = restore_by_id(&trash_store, &nonexistent_id.to_string(), &opts, false);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -335,12 +355,12 @@ mod tests {
 
         // Restore to specific directory
         let restore_target = restore_dir.path().to_path_buf();
-        let result = restore_by_id(
-            &trash_store,
-            &id.to_string(),
-            Some(restore_target.clone()),
-            false,
-        );
+        let opts = RestoreOpts {
+            to: Some(restore_target.clone()),
+            force: false,
+            rename: false,
+        };
+        let result = restore_by_id(&trash_store, &id.to_string(), &opts, false);
         assert!(result.is_ok());
 
         // Check if file was restored to the new location

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -37,8 +37,8 @@ pub fn execute(detailed: bool, verbose: bool) -> Result<()> {
     println!("🗑️  Trash Status");
     println!("{}", "─".repeat(50));
     println!("📁 Location: {}", config.trash_path.display());
-    println!("📊 Files: {}", total_files);
-    println!("💾 Total Size: {}", total_size_human);
+    println!("📊 Files: {total_files}");
+    println!("💾 Total Size: {total_size_human}");
 
     if let (Some(oldest), Some(newest)) = (oldest, newest) {
         println!("🕐 Oldest: {}", oldest.format("%Y-%m-%d %H:%M:%S"));
@@ -114,19 +114,19 @@ fn show_time_breakdown(items: &[TrashItem]) -> Result<()> {
 
     println!("\n⏰ By Time Period:");
     if today > 0 {
-        println!("   Today:      {}", today);
+        println!("   Today:      {today}");
     }
     if yesterday > 0 {
-        println!("   Yesterday:  {}", yesterday);
+        println!("   Yesterday:  {yesterday}");
     }
     if this_week > 0 {
-        println!("   This week:  {}", this_week);
+        println!("   This week:  {this_week}");
     }
     if this_month > 0 {
-        println!("   This month: {}", this_month);
+        println!("   This month: {this_month}");
     }
     if older > 0 {
-        println!("   Older:      {}", older);
+        println!("   Older:      {older}");
     }
 
     Ok(())
@@ -160,7 +160,7 @@ fn show_file_type_breakdown(items: &[TrashItem]) -> Result<()> {
 
         if sorted_types.len() > 10 {
             let remaining = sorted_types.len() - 10;
-            println!("   ... and {} more types", remaining);
+            println!("   ... and {remaining} more types");
         }
     }
 
@@ -184,16 +184,16 @@ fn show_size_breakdown(items: &[TrashItem]) -> Result<()> {
 
     println!("\n📏 By File Size:");
     if small > 0 {
-        println!("   Small (< 1KB):     {}", small);
+        println!("   Small (< 1KB):     {small}");
     }
     if medium > 0 {
-        println!("   Medium (1KB-1MB):  {}", medium);
+        println!("   Medium (1KB-1MB):  {medium}");
     }
     if large > 0 {
-        println!("   Large (1MB-100MB): {}", large);
+        println!("   Large (1MB-100MB): {large}");
     }
     if huge > 0 {
-        println!("   Huge (> 100MB):    {}", huge);
+        println!("   Huge (> 100MB):    {huge}");
     }
 
     Ok(())
@@ -217,19 +217,19 @@ fn show_tag_breakdown(items: &[TrashItem]) -> Result<()> {
         println!("\n🏷️  By Tags:");
 
         if untagged > 0 {
-            println!("   (no tags): {}", untagged);
+            println!("   (no tags): {untagged}");
         }
 
         let mut sorted_tags: Vec<_> = tag_counts.iter().collect();
         sorted_tags.sort_by(|a, b| b.1.cmp(a.1));
 
         for (tag, count) in sorted_tags.iter().take(10) {
-            println!("   {}: {}", tag, count);
+            println!("   {tag}: {count}");
         }
 
         if sorted_tags.len() > 10 {
             let remaining = sorted_tags.len() - 10;
-            println!("   ... and {} more tags", remaining);
+            println!("   ... and {remaining} more tags");
         }
     }
 
@@ -257,7 +257,7 @@ fn show_storage_breakdown(items: &[TrashItem], config: &crate::domain::Config) -
 
         if sorted_dates.len() > 7 {
             let remaining = sorted_dates.len() - 7;
-            println!("   ... and {} more dates", remaining);
+            println!("   ... and {remaining} more dates");
         }
     }
 
@@ -295,7 +295,7 @@ fn show_recent_activity(items: &[TrashItem]) -> Result<()> {
             let size = format_size(item.meta.size);
             let time_ago = format_time_ago(now.signed_duration_since(item.meta.deleted_at));
 
-            println!("   {} ({}) - {}", filename, size, time_ago);
+            println!("   {filename} ({size}) - {time_ago}");
         }
 
         if recent_items.len() > 5 {
@@ -457,10 +457,10 @@ mod tests {
         let test_file1 = NamedTempFile::new().unwrap();
         let test_file2 = NamedTempFile::new().unwrap();
         fs::write(test_file1.path(), "small content").unwrap();
-        fs::write(test_file2.path(), &vec![0u8; 2048]).unwrap(); // 2KB file
+        fs::write(test_file2.path(), vec![0u8; 2048]).unwrap(); // 2KB file
 
-        let mut meta1 = FileMeta::from_path(&test_file1.path()).unwrap();
-        let mut meta2 = FileMeta::from_path(&test_file2.path()).unwrap();
+        let mut meta1 = FileMeta::from_path(test_file1.path()).unwrap();
+        let mut meta2 = FileMeta::from_path(test_file2.path()).unwrap();
 
         // Add different tags
         meta1.add_tag("test".to_string());

--- a/src/domain/config.rs
+++ b/src/domain/config.rs
@@ -235,8 +235,10 @@ mod tests {
     #[test]
     fn test_ensure_directories() {
         let temp_dir = TempDir::new().unwrap();
-        let mut config = Config::default();
-        config.trash_path = temp_dir.path().join("test_trash");
+        let config = Config {
+            trash_path: temp_dir.path().join("test_trash"),
+            ..Default::default()
+        };
 
         config.ensure_directories().unwrap();
 

--- a/src/domain/file_meta.rs
+++ b/src/domain/file_meta.rs
@@ -172,7 +172,7 @@ mod tests {
         let meta1 = FileMeta::from_path(&path).unwrap();
         assert_eq!(meta1.human_readable_size(), "1 B");
 
-        fs::write(&path, &vec![0u8; 1536]).unwrap(); // 1.5 KB
+        fs::write(&path, vec![0u8; 1536]).unwrap(); // 1.5 KB
         let meta2 = FileMeta::from_path(&path).unwrap();
         assert_eq!(meta2.human_readable_size(), "1.5 KB");
     }

--- a/src/domain/operation_log.rs
+++ b/src/domain/operation_log.rs
@@ -105,7 +105,7 @@ impl OperationLog {
     pub fn result_display(&self) -> String {
         match &self.result {
             OperationResult::Success => "✅ Success".to_string(),
-            OperationResult::Failed(error) => format!("❌ Failed: {}", error),
+            OperationResult::Failed(error) => format!("❌ Failed: {error}"),
             OperationResult::Cancelled => "⚠️ Cancelled".to_string(),
         }
     }
@@ -130,7 +130,7 @@ impl OperationLog {
             "unknown".to_string()
         };
 
-        format!("{} {}", operation_name, paths_str)
+        format!("{operation_name} {paths_str}")
     }
 }
 
@@ -183,7 +183,7 @@ impl OperationLogger {
                 match serde_json::from_str::<OperationLog>(line) {
                     Ok(log) => logs.push(log),
                     Err(e) => {
-                        eprintln!("Warning: Failed to parse log line: {}", e);
+                        eprintln!("Warning: Failed to parse log line: {e}");
                         // Continue parsing other lines
                     }
                 }

--- a/src/infra/meta_store.rs
+++ b/src/infra/meta_store.rs
@@ -22,7 +22,7 @@ impl MetaStore {
     }
 
     fn metadata_file_path(&self, id: &Uuid) -> PathBuf {
-        self.metadata_dir.join(format!("{}.json", id))
+        self.metadata_dir.join(format!("{id}.json"))
     }
 }
 
@@ -66,7 +66,7 @@ impl MetaStoreInterface for MetaStore {
                 match serde_json::from_str::<FileMeta>(&content) {
                     Ok(meta) => metadata_list.push(meta),
                     Err(e) => {
-                        eprintln!("Warning: Failed to parse metadata file {:?}: {}", path, e);
+                        eprintln!("Warning: Failed to parse metadata file {path:?}: {e}");
                     }
                 }
             }
@@ -104,7 +104,7 @@ mod tests {
         // Create test metadata
         let test_file = NamedTempFile::new().unwrap();
         fs::write(test_file.path(), "content").unwrap();
-        let meta = FileMeta::from_path(&test_file.path().to_path_buf()).unwrap();
+        let meta = FileMeta::from_path(test_file.path()).unwrap();
 
         // Save metadata
         meta_store.save_metadata(&meta).unwrap();
@@ -130,8 +130,8 @@ mod tests {
         fs::write(test_file1.path(), "content1").unwrap();
         fs::write(test_file2.path(), "content2").unwrap();
 
-        let meta1 = FileMeta::from_path(&test_file1.path().to_path_buf()).unwrap();
-        let meta2 = FileMeta::from_path(&test_file2.path().to_path_buf()).unwrap();
+        let meta1 = FileMeta::from_path(test_file1.path()).unwrap();
+        let meta2 = FileMeta::from_path(test_file2.path()).unwrap();
 
         meta_store.save_metadata(&meta1).unwrap();
         meta_store.save_metadata(&meta2).unwrap();
@@ -151,7 +151,7 @@ mod tests {
 
         let test_file = NamedTempFile::new().unwrap();
         fs::write(test_file.path(), "content").unwrap();
-        let meta = FileMeta::from_path(&test_file.path().to_path_buf()).unwrap();
+        let meta = FileMeta::from_path(test_file.path()).unwrap();
 
         // Save and then delete
         meta_store.save_metadata(&meta).unwrap();

--- a/src/infra/trash_store.rs
+++ b/src/infra/trash_store.rs
@@ -102,10 +102,8 @@ impl TrashStoreInterface for TrashStore {
                 items.push(TrashItem::new(meta, trash_path));
             } else {
                 // File is missing, optionally clean up metadata
-                eprintln!(
-                    "Warning: Metadata exists but file missing for ID: {}",
-                    meta.id
-                );
+                let id = meta.id;
+                eprintln!("Warning: Metadata exists but file missing for ID: {id}");
             }
         }
 
@@ -138,7 +136,7 @@ impl TrashStoreInterface for TrashStore {
                 Ok(Some(TrashItem::new(meta, trash_path)))
             } else {
                 // Metadata exists but file is missing
-                eprintln!("Warning: Metadata exists but file missing for ID: {}", id);
+                eprintln!("Warning: Metadata exists but file missing for ID: {id}");
                 Ok(None)
             }
         } else {
@@ -161,17 +159,16 @@ mod tests {
 
         // Create a test file
         let test_file = NamedTempFile::new().unwrap();
-        let file_path = test_file.path().to_path_buf();
-        fs::write(&file_path, "test content").unwrap();
+        fs::write(test_file.path(), "test content").unwrap();
 
         // Create metadata
-        let meta = FileMeta::from_path(&file_path).unwrap();
+        let meta = FileMeta::from_path(test_file.path()).unwrap();
 
         // Save to trash
-        let trash_item = trash_store.save(&meta, &file_path).unwrap();
+        let trash_item = trash_store.save(&meta, test_file.path()).unwrap();
 
         // Verify file was moved
-        assert!(!file_path.exists());
+        assert!(!test_file.path().exists());
         assert!(trash_item.trash_path.exists());
         assert_eq!(
             fs::read_to_string(&trash_item.trash_path).unwrap(),
@@ -185,7 +182,7 @@ mod tests {
         let trash_store = TrashStore::new(temp_dir.path().to_path_buf());
 
         let test_file = NamedTempFile::new().unwrap();
-        let meta = FileMeta::from_path(&test_file.path().to_path_buf()).unwrap();
+        let meta = FileMeta::from_path(test_file.path()).unwrap();
 
         let filename = trash_store.generate_trash_filename(&meta);
         assert!(filename.ends_with(".rmz"));
@@ -212,8 +209,8 @@ mod tests {
         fs::write(test_file1.path(), "content1").unwrap();
         fs::write(test_file2.path(), "content2").unwrap();
 
-        let meta1 = FileMeta::from_path(&test_file1.path().to_path_buf()).unwrap();
-        let meta2 = FileMeta::from_path(&test_file2.path().to_path_buf()).unwrap();
+        let meta1 = FileMeta::from_path(test_file1.path()).unwrap();
+        let meta2 = FileMeta::from_path(test_file2.path()).unwrap();
 
         trash_store.save(&meta1, test_file1.path()).unwrap();
         trash_store.save(&meta2, test_file2.path()).unwrap();
@@ -231,7 +228,7 @@ mod tests {
         // Create and save test file
         let test_file = NamedTempFile::new().unwrap();
         fs::write(test_file.path(), "content").unwrap();
-        let meta = FileMeta::from_path(&test_file.path().to_path_buf()).unwrap();
+        let meta = FileMeta::from_path(test_file.path()).unwrap();
 
         trash_store.save(&meta, test_file.path()).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod commands;
 pub mod core;
 pub mod domain;
 pub mod infra;
+pub mod utils;

--- a/src/utils/file_safety.rs
+++ b/src/utils/file_safety.rs
@@ -1,0 +1,113 @@
+use anyhow::Result;
+use dialoguer::Select;
+use std::path::{Path, PathBuf};
+
+/// Possible actions when a restore target already exists
+pub enum RestoreAction {
+    Overwrite,
+    Skip,
+    Rename,
+    Cancel,
+    Proceed,
+}
+
+/// Check if the restore path already exists and ask user how to proceed
+pub fn check_existing_file(restore_path: &Path) -> Result<RestoreAction> {
+    if restore_path.exists() {
+        let metadata = std::fs::metadata(restore_path)?;
+        println!("\u{26a0}\u{fe0f}  File already exists:");
+        println!("   Path: {}", restore_path.display());
+        println!("   Size: {}", format_size(metadata.len()));
+        if let Ok(modified) = metadata.modified() {
+            println!("   Modified: {modified:?}");
+        }
+
+        let selection = Select::new()
+            .with_prompt("How to proceed?")
+            .items(&[
+                "Overwrite existing file",
+                "Skip restoration",
+                "Rename restored file",
+                "Cancel operation",
+            ])
+            .default(1)
+            .interact()?;
+
+        let action = match selection {
+            0 => RestoreAction::Overwrite,
+            1 => RestoreAction::Skip,
+            2 => RestoreAction::Rename,
+            _ => RestoreAction::Cancel,
+        };
+        Ok(action)
+    } else {
+        Ok(RestoreAction::Proceed)
+    }
+}
+
+/// Generate a non-conflicting restore path by appending an incremental suffix
+pub fn generate_safe_restore_path(original: &Path) -> PathBuf {
+    let mut counter = 1;
+    loop {
+        let new_path = if let Some(stem) = original.file_stem() {
+            let ext = original
+                .extension()
+                .map(|e| format!(".{}", e.to_string_lossy()))
+                .unwrap_or_default();
+            original.with_file_name(format!(
+                "{}_restored_{counter}{}",
+                stem.to_string_lossy(),
+                ext
+            ))
+        } else {
+            original.with_extension(format!("restored_{counter}"))
+        };
+
+        if !new_path.exists() {
+            return new_path;
+        }
+        counter += 1;
+    }
+}
+
+fn format_size(size: u64) -> String {
+    const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB"];
+    let mut size_f = size as f64;
+    let mut unit_index = 0;
+
+    while size_f >= 1024.0 && unit_index < UNITS.len() - 1 {
+        size_f /= 1024.0;
+        unit_index += 1;
+    }
+
+    if unit_index == 0 {
+        format!("{} {}", size, UNITS[0])
+    } else {
+        format!("{:.1} {}", size_f, UNITS[unit_index])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_generate_safe_restore_path() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("example.txt");
+        fs::write(&file, "a").unwrap();
+        let new_path = generate_safe_restore_path(&file);
+        assert!(new_path != file);
+        assert!(!new_path.exists());
+    }
+
+    #[test]
+    fn test_check_existing_file_proceed() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("missing.txt");
+        let action = check_existing_file(&path).unwrap();
+        matches!(action, RestoreAction::Proceed);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod file_safety;


### PR DESCRIPTION
## Summary
- add interactive existing file checks and auto-rename utilities
- extend CLI with `--force` and `--rename` for `restore`
- update restore logic to prevent accidental overwrites
- document new restore options
- run `rustfmt` to fix CI formatting errors
- refactor restore argument handling to satisfy clippy
- fix remaining lint warnings

## Testing
- `cargo +nightly test --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 /usr/bin/rustfmt --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_b_685975066d78832fabd2c5a0890466e7