### PR TITLE
TOCTOU安全を改善

### DIFF
--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -2,6 +2,7 @@ use crate::domain::{Config, FileMeta};
 use crate::infra::meta_store::MetaStoreInterface;
 use crate::infra::trash_store::TrashStoreInterface;
 use crate::infra::{ConfigManager, MetaStore, TrashStore};
+use crate::ops::safe_file_ops::FileSnapshot;
 use anyhow::Result;
 use std::path::PathBuf;
 
@@ -36,7 +37,14 @@ pub fn execute(
             interactive,
             verbose,
         };
-        match delete_single_file(&path, &config, &trash_store, &meta_store, &tag, &options) {
+        match delete_single_file(
+            path.as_path(),
+            &config,
+            &trash_store,
+            &meta_store,
+            &tag,
+            &options,
+        ) {
             Ok(meta) => {
                 deleted_files.push(meta);
                 if verbose {
@@ -66,30 +74,28 @@ struct DeleteOptions {
 }
 
 fn delete_single_file(
-    path: &PathBuf,
+    path: &std::path::Path,
     config: &Config,
     trash_store: &TrashStore,
     meta_store: &MetaStore,
     tag: &Option<String>,
     options: &DeleteOptions,
 ) -> Result<FileMeta> {
-    // Check if file exists
-    if !path.exists() {
-        anyhow::bail!("File does not exist: {}", path.display());
-    }
+    // Capture snapshot of the file for TOCTOU-safe operations
+    let snapshot = FileSnapshot::capture(path)?;
 
-    // Check if path is protected
-    if config.is_protected(path) {
+    // Check if path is protected using the snapshot path
+    if config.is_protected(&snapshot.path) {
         anyhow::bail!("Path is protected from deletion: {}", path.display());
     }
 
     // Interactive confirmation if needed
-    if options.interactive && !options.force && !confirm_deletion(path)? {
+    if options.interactive && !options.force && !confirm_deletion(&snapshot.path)? {
         anyhow::bail!("Deletion cancelled by user");
     }
 
-    // Create metadata
-    let mut meta = FileMeta::from_path(path.as_path())?;
+    // Create metadata from snapshot
+    let mut meta = FileMeta::from_snapshot(&snapshot)?;
 
     // Add tag if provided
     if let Some(tag_value) = tag {
@@ -97,11 +103,11 @@ fn delete_single_file(
     }
 
     if options.verbose {
-        println!("Moving {} to trash...", path.display());
+        println!("Moving {} to trash...", snapshot.path.display());
     }
 
     // Move to trash and save metadata
-    let _trash_item = trash_store.save(&meta, path)?;
+    let _trash_item = trash_store.save(&meta, &snapshot.path)?;
     meta_store.save_metadata(&meta)?;
 
     Ok(meta)
@@ -148,7 +154,7 @@ mod tests {
             verbose: false,
         };
         let result = delete_single_file(
-            &file_path,
+            file_path.as_path(),
             &config,
             &trash_store,
             &meta_store,
@@ -183,7 +189,7 @@ mod tests {
             verbose: false,
         };
         let result = delete_single_file(
-            &nonexistent_path,
+            nonexistent_path.as_path(),
             &config,
             &trash_store,
             &meta_store,
@@ -195,7 +201,7 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("File does not exist"));
+            .contains("Cannot read metadata"));
     }
 
     #[test]
@@ -222,7 +228,7 @@ mod tests {
             verbose: false,
         };
         let result = delete_single_file(
-            &protected_file,
+            protected_file.as_path(),
             &config,
             &trash_store,
             &meta_store,

--- a/src/domain/file_meta.rs
+++ b/src/domain/file_meta.rs
@@ -64,6 +64,26 @@ impl FileMeta {
         })
     }
 
+    /// Create FileMeta from a [`FileSnapshot`]
+    pub fn from_snapshot(
+        snapshot: &crate::ops::safe_file_ops::FileSnapshot,
+    ) -> anyhow::Result<Self> {
+        let deleted_by = std::env::var("USER")
+            .or_else(|_| std::env::var("USERNAME"))
+            .unwrap_or_else(|_| "unknown".to_string());
+
+        Ok(Self {
+            id: Uuid::new_v4(),
+            original_path: snapshot.path.clone(),
+            deleted_at: Utc::now(),
+            size: snapshot.size,
+            permissions: snapshot.permissions,
+            tags: Vec::new(),
+            checksum: None,
+            deleted_by,
+        })
+    }
+
     /// Add a tag to this file
     pub fn add_tag(&mut self, tag: String) {
         if !self.tags.contains(&tag) {

--- a/src/infra/trash_store.rs
+++ b/src/infra/trash_store.rs
@@ -1,5 +1,6 @@
 use crate::domain::{FileMeta, TrashItem};
 use crate::infra::{meta_store::MetaStoreInterface, MetaStore};
+use crate::ops::safe_file_ops::SafeFileOperation;
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
@@ -50,8 +51,8 @@ impl TrashStoreInterface for TrashStore {
         let filename = self.generate_trash_filename(meta);
         let trash_path = date_dir.join(&filename);
 
-        // Move file to trash
-        std::fs::rename(source_path, &trash_path)?;
+        // Move file to trash using safe operation
+        SafeFileOperation::atomic_move(source_path, &trash_path)?;
 
         // Save metadata through MetaStore
         self.meta_store.save_metadata(meta)?;
@@ -69,8 +70,8 @@ impl TrashStoreInterface for TrashStore {
                 std::fs::create_dir_all(parent)?;
             }
 
-            // Move file back
-            std::fs::rename(&item.trash_path, original_path)?;
+            // Move file back using safe operation
+            SafeFileOperation::atomic_move(&item.trash_path, original_path)?;
 
             // Remove metadata after successful restore
             self.meta_store.delete_metadata(id)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod commands;
 pub mod core;
 pub mod domain;
 pub mod infra;
+pub mod ops;

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,0 +1,1 @@
+pub mod safe_file_ops;

--- a/src/ops/safe_file_ops.rs
+++ b/src/ops/safe_file_ops.rs
@@ -1,0 +1,142 @@
+use anyhow::{Context, Result};
+use std::fs::{self, File, Metadata};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+#[derive(Debug, Clone)]
+pub struct FileSnapshot {
+    pub path: PathBuf,
+    pub inode: u64,
+    pub size: u64,
+    pub modified: SystemTime,
+    pub permissions: u32,
+}
+
+impl FileSnapshot {
+    pub fn capture(path: &Path) -> Result<Self> {
+        let metadata = fs::metadata(path)
+            .with_context(|| format!("Cannot read metadata: {}", path.display()))?;
+        Ok(Self::from_metadata(path.to_path_buf(), &metadata))
+    }
+
+    pub fn from_metadata(path: PathBuf, metadata: &Metadata) -> Self {
+        #[cfg(unix)]
+        use std::os::unix::fs::MetadataExt;
+
+        #[cfg(unix)]
+        let inode = metadata.ino();
+        #[cfg(not(unix))]
+        let inode = 0;
+
+        #[cfg(unix)]
+        let permissions = metadata.mode();
+        #[cfg(not(unix))]
+        let permissions = 0u32;
+
+        Self {
+            path,
+            inode,
+            size: metadata.len(),
+            modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+            permissions,
+        }
+    }
+
+    pub fn verify_unchanged(&self) -> Result<()> {
+        let current = Self::capture(&self.path)?;
+        if current.inode != self.inode
+            || current.size != self.size
+            || current.modified != self.modified
+            || current.permissions != self.permissions
+        {
+            anyhow::bail!("File changed during operation: {}", self.path.display());
+        }
+        Ok(())
+    }
+}
+
+pub struct SafeFileOperation;
+
+impl SafeFileOperation {
+    /// Perform an atomic file move with TOCTOU checks.
+    pub fn atomic_move(source: &Path, target: &Path) -> Result<()> {
+        let source_file = File::open(source)
+            .with_context(|| format!("Cannot open source file: {}", source.display()))?;
+        let source_metadata = source_file
+            .metadata()
+            .with_context(|| "Cannot read source file metadata")?;
+
+        if !source_metadata.is_file() {
+            anyhow::bail!("Source is not a regular file: {}", source.display());
+        }
+
+        let snapshot = FileSnapshot::from_metadata(source.to_path_buf(), &source_metadata);
+
+        Self::execute_atomic_move(&source_file, source, target, &snapshot)
+    }
+
+    fn execute_atomic_move(
+        source_file: &File,
+        source_path: &Path,
+        target_path: &Path,
+        snapshot: &FileSnapshot,
+    ) -> Result<()> {
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        #[cfg(unix)]
+        {
+            snapshot.verify_unchanged()?;
+            fs::rename(source_path, target_path).with_context(|| "Atomic rename failed")?;
+        }
+
+        #[cfg(windows)]
+        {
+            snapshot.verify_unchanged()?;
+            Self::windows_atomic_move(source_path, target_path)?;
+        }
+
+        let _ = source_file; // suppress unused variable on non-Unix
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    fn windows_atomic_move(source: &Path, target: &Path) -> Result<()> {
+        // TODO: use Windows MoveFileEx for true atomicity
+        fs::rename(source, target).with_context(|| "Atomic move failed on Windows")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn snapshot_detects_change() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("test.txt");
+        fs::write(&file_path, "content").unwrap();
+
+        let snapshot = FileSnapshot::capture(&file_path).unwrap();
+        fs::write(&file_path, "new content").unwrap();
+
+        assert!(snapshot.verify_unchanged().is_err());
+    }
+
+    #[test]
+    fn atomic_move_moves_file() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src.txt");
+        let dst = dir.path().join("dst.txt");
+        fs::write(&src, "hello").unwrap();
+
+        SafeFileOperation::atomic_move(&src, &dst).unwrap();
+
+        assert!(!src.exists());
+        assert!(dst.exists());
+        assert_eq!(fs::read_to_string(&dst).unwrap(), "hello");
+    }
+}


### PR DESCRIPTION
## Summary
- add `FileMeta::from_snapshot` to build metadata from a pre-check snapshot
- `delete_single_file` now captures a `FileSnapshot` before verifying or moving
- tests expect the new metadata error message for missing files

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_b_6859751c3c08832fa2e8c60ba8840e56